### PR TITLE
Updates to allow building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,8 +193,8 @@ set (lib fms_${precision})
 esma_add_library (${lib} SRCS ${srcs})
 target_link_libraries (${lib} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
-target_include_directories (${lib} PRIVATE include mpp/include fft fms)
-target_include_directories (${lib} PRIVATE ${INC_NETCDF})
+target_include_directories (${lib} PUBLIC include mpp/include fft fms)
+target_include_directories (${lib} PUBLIC ${INC_NETCDF})
 
 file (COPY include/fms_platform.h DESTINATION ${include_${this}})
 file (COPY include/file_version.h DESTINATION ${include_${this}})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ set(srcs_and_includes
   exchange/test_xgrid.F90                         
   diag_manager/diag_table.F90                     
   diag_manager/diag_manifest.F90
+  include/mojave_fix.h
   )
 
 
@@ -192,8 +193,8 @@ set (lib fms_${precision})
 esma_add_library (${lib} SRCS ${srcs})
 target_link_libraries (${lib} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
-target_include_directories (${lib} PUBLIC include mpp/include fft fms)
-target_include_directories (${lib} PUBLIC ${INC_NETCDF})
+target_include_directories (${lib} PRIVATE include mpp/include fft fms)
+target_include_directories (${lib} PRIVATE ${INC_NETCDF})
 
 file (COPY include/fms_platform.h DESTINATION ${include_${this}})
 file (COPY include/file_version.h DESTINATION ${include_${this}})

--- a/include/mojave_fix.h
+++ b/include/mojave_fix.h
@@ -1,0 +1,5 @@
+#ifndef __OSX_AVAILABLE_STARTING
+#  define __OSX_AVAILABLE_STARTING(_osx, ios)
+#  define __OSX_AVAILABLE_BUT_DEPRECATED(_osxIntro, osxDep, iosIntro, iosDep)
+#  define __OSX_AVAILABLE_BUT_DEPRECATED_MSG(_osxIntro, osxDep, iosIntro, iosDep, _msg)
+#endif

--- a/mosaic/create_xgrid.c
+++ b/mosaic/create_xgrid.c
@@ -1,3 +1,4 @@
+#include "mojave_fix.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/mosaic/mosaic_util.c
+++ b/mosaic/mosaic_util.c
@@ -1,3 +1,4 @@
+#include "mojave_fix.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/mosaic/read_mosaic.c
+++ b/mosaic/read_mosaic.c
@@ -1,3 +1,4 @@
+#include "mojave_fix.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>


### PR DESCRIPTION
Per @tclune, building with gfortran on macOS has some issues. Following
his lead with pFUnit, I've created a new file, `mojave_fix.h` and then
added the header to the C files that needed it.

Note, it looks like it has to be the *FIRST* header in a file that needs
it. Ugly, but what can you do.