### PR TITLE
More elegant macOS fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,6 @@ set(srcs_and_includes
   exchange/test_xgrid.F90                         
   diag_manager/diag_table.F90                     
   diag_manager/diag_manifest.F90
-  include/mojave_fix.h
   )
 
 

--- a/include/mojave_fix.h
+++ b/include/mojave_fix.h
@@ -1,5 +1,0 @@
-#ifndef __OSX_AVAILABLE_STARTING
-#  define __OSX_AVAILABLE_STARTING(_osx, ios)
-#  define __OSX_AVAILABLE_BUT_DEPRECATED(_osxIntro, osxDep, iosIntro, iosDep)
-#  define __OSX_AVAILABLE_BUT_DEPRECATED_MSG(_osxIntro, osxDep, iosIntro, iosDep, _msg)
-#endif

--- a/mosaic/create_xgrid.c
+++ b/mosaic/create_xgrid.c
@@ -1,6 +1,5 @@
-#include "mojave_fix.h"
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include "mosaic_util.h"
 #include "create_xgrid.h"

--- a/mosaic/mosaic_util.c
+++ b/mosaic/mosaic_util.c
@@ -1,6 +1,5 @@
-#include "mojave_fix.h"
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #ifdef use_libMPI

--- a/mosaic/read_mosaic.c
+++ b/mosaic/read_mosaic.c
@@ -1,6 +1,5 @@
-#include "mojave_fix.h"
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include "read_mosaic.h"


### PR DESCRIPTION
In researching what to put in the release notes for the previous macOS fix, I found [this thread](https://github.com/Homebrew/homebrew-core/issues/40676#issuecomment-513506908) which seems to state that all that's often necessary is to include `stdio.h` before `stdlib.h`.

So, I've reversed those two libs and removed the `mojave_fix.h` include and file ane reverted the `CMakeLists.txt`.