### PR TITLE
Update to NOAA FMS 2019.01.02 tag & Remove Affinity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,9 @@ set(srcs_and_includes
    topography/topography.F90
    tracer_manager/tracer_manager.F90
    tridiagonal/tridiagonal.F90
+   #affinity/affinity.c
+   #affinity/fms_affinity.F90
+   #affinity/test_affinity.F90
    )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,9 +196,6 @@ set(srcs_and_includes
    topography/topography.F90
    tracer_manager/tracer_manager.F90
    tridiagonal/tridiagonal.F90
-   affinity/affinity.c
-   affinity/fms_affinity.F90
-   affinity/test_affinity.F90
    )
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.59])
 
 # Initialize with name, version, and support email address.
 AC_INIT([GFDL FMS Library],
-  [2019.01],
+  [2019.01.02],
   [gfdl.climate.model.info@noaa.gov],
   [FMS],
   [https://www.gfdl.noaa.gov/fms])

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -35,6 +35,7 @@ MODULE diag_axis_mod
 
   USE mpp_domains_mod, ONLY: domainUG, domain1d, domain2d, mpp_get_compute_domain,&
        & mpp_get_domain_components, null_domain1d, null_domain2d, null_domainUG,&
+       & NORTH, EAST, CENTER, &
        & OPERATOR(.NE.), mpp_get_global_domain, mpp_get_domain_name
   USE fms_mod, ONLY: error_mesg, write_version_number, lowercase, uppercase,&
        & fms_error_handler, FATAL, NOTE
@@ -54,7 +55,8 @@ MODULE diag_axis_mod
        & get_tile_count, get_axes_shift, get_diag_axis_name,&
        & get_axis_num, get_diag_axis_domain_name, diag_axis_add_attribute,&
        & get_domainUG, axis_compatible_check, axis_is_compressed, &
-       & get_compressed_axes_ids, get_axis_reqfld
+       & get_compressed_axes_ids, get_axis_reqfld, &
+       & NORTH, EAST, CENTER
 
   ! Module variables
   ! Parameters
@@ -152,8 +154,11 @@ CONTAINS
   !     Required field names.
   !   </IN>
   !   <IN NAME="tile_count" TYPE="INTEGER, OPTIONAL" />
+  !   <IN NAME="domain_position" TYPE="INTEGER, OPTIONAL">
+  !     NOT USED. This is for use in future releases.
+  !   </IN>
   INTEGER FUNCTION diag_axis_init(name, DATA, units, cart_name, long_name, direction,&
-       & set_name, edges, Domain, Domain2, DomainU, aux, req, tile_count)
+       & set_name, edges, Domain, Domain2, DomainU, aux, req, tile_count, domain_position)
     CHARACTER(len=*), INTENT(in) :: name
     REAL, DIMENSION(:), INTENT(in) :: DATA
     CHARACTER(len=*), INTENT(in) :: units
@@ -165,6 +170,7 @@ CONTAINS
     TYPE(domainUG), INTENT(in), OPTIONAL :: DomainU
     CHARACTER(len=*), INTENT(in), OPTIONAL :: aux, req
     INTEGER, INTENT(in), OPTIONAL :: tile_count
+    INTEGER, INTENT(in), OPTIONAL :: domain_position
 
     TYPE(domain1d) :: domain_x, domain_y
     INTEGER :: ierr, axlen

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -213,7 +213,7 @@ MODULE diag_manager_mod
        & file_exist, fms_error_handler, check_nml_error, get_mosaic_tile_file, lowercase
   USE fms_io_mod, ONLY: get_instance_filename
   USE diag_axis_mod, ONLY: diag_axis_init, get_axis_length, get_axis_num, get_domain2d, get_tile_count,&
-       & diag_axis_add_attribute, axis_compatible_check
+       & diag_axis_add_attribute, axis_compatible_check, CENTER, NORTH, EAST
   USE diag_util_mod, ONLY: get_subfield_size, log_diag_field_info, update_bounds,&
        & check_out_of_bounds, check_bounds_are_exact_dynamic, check_bounds_are_exact_static,&
        & diag_time_inc, find_input_field, init_input_field, init_output_field,&
@@ -256,6 +256,7 @@ MODULE diag_manager_mod
        & DIAG_MINUTES, DIAG_HOURS, DIAG_DAYS, DIAG_MONTHS, DIAG_YEARS, get_diag_global_att,&
        & set_diag_global_att, diag_field_add_attribute, diag_field_add_cell_measures,&
        & get_diag_field_id, diag_axis_add_attribute
+  PUBLIC :: CENTER, NORTH, EAST !< Used for diag_axis_init
   ! Public interfaces from diag_grid_mod
   PUBLIC :: diag_grid_init, diag_grid_end
   PUBLIC :: diag_manager_set_time_end, diag_send_complete

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES = libFMS.la
 # These linker flags specify libtool version info.
 # See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 # for information regarding incrementing `-version-info`.
-libFMS_la_LDFLAGS = -version-info 2:0:0
+libFMS_la_LDFLAGS = -version-info 2:2:1
 
 # Add the convenience libraries to the FMS library.
 libFMS_la_LIBADD = ${top_builddir}/platform/libplatform.la


### PR DESCRIPTION
This update has two purposes:

1. It updates GEOS-ESM/FMS to be equivalent to the NOAA-GFDL/FMS 2019.01.02 tag.
2. It removes the `affinity/` code from being built in CMake. This is being done because of #12. On recent Fedora (and maybe *any* recent Linux OS, the affinity code will cause issues. For GEOS purposes, we *do not use* the FMS affinity code, so not compiling it is a simple "fix"