### PR TITLE
Fix for flush issue on macOS

### DIFF
--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -236,7 +236,7 @@ subroutine mpp_exit()
      end if
 
      call mpp_sync()
-     call FLUSH( out_unit )
+     flush( out_unit )
 
      if( pe.EQ.root_pe )then
         write( out_unit,'(/a,i6,a)' ) 'Tabulating mpp_clock statistics across ', npes, ' PEs...'
@@ -246,7 +246,7 @@ subroutine mpp_exit()
      end if
      write( log_unit,'(/37x,a)' ) 'time'
 
-     call FLUSH( out_unit )
+     flush( out_unit )
      call mpp_sync()
      do i = 1,clock_num
         if( .NOT.ANY(peset(clocks(i)%peset_num)%list(:).EQ.pe) )cycle
@@ -301,12 +301,12 @@ subroutine mpp_exit()
 
   end if
 
-  call FLUSH( out_unit )
+  flush( out_unit )
 
 ! close down etc_unit: 9
   inquire(unit=etc_unit, opened=opened)
   if (opened) then
-   call FLUSH (etc_unit)
+   flush (etc_unit)
    close(etc_unit)
   endif
 

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -193,7 +193,7 @@ subroutine mpp_exit()
      else
         write( out_unit,'(/37x,a)' ) 'time'
      end if
-     call FLUSH( out_unit )
+     flush( out_unit )
      call mpp_sync()
      do i = 1,clock_num
         if( .NOT.ANY(peset(clocks(i)%peset_num)%list(:).EQ.pe) )cycle
@@ -244,7 +244,7 @@ subroutine mpp_exit()
 ! close down etc_unit: 9
   inquire(unit=etc_unit, opened=opened)
   if (opened) then
-   call FLUSH (etc_unit)
+   flush (etc_unit)
    close(etc_unit)
   endif
 

--- a/mpp/include/mpp_comm_sma.inc
+++ b/mpp/include/mpp_comm_sma.inc
@@ -227,7 +227,7 @@ subroutine mpp_exit()
         write( outunit,'(/32x,a)' ) '          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
      end if
      write( logunit, '(/37x,a)' ) 'time'
-     call FLUSH( outunit )
+     flush( outunit )
      call mpp_sync()
      do i = 1,clock_num
         if( .NOT.ANY(peset(clocks(i)%peset_num)%list(:).EQ.pe) )cycle
@@ -277,7 +277,7 @@ subroutine mpp_exit()
 ! close down etc_unit: 9
   inquire(unit=etc_unit, opened=opened)
   if (opened) then
-   call FLUSH (etc_unit)
+   flush (etc_unit)
    close(etc_unit)
   endif
 

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -2120,7 +2120,7 @@ end subroutine check_message_size
                   overlapList(m)%dir(n), overlapList(m)%rotation(n)
           enddo
        enddo
-       if(nsend >0) call flush(unit)
+       if(nsend >0) flush(unit)
     endif
 
     ! copy the overlapping information into domain data structure
@@ -2697,7 +2697,7 @@ end subroutine check_message_size
                   overlapList(m)%dir(n), overlapList(m)%rotation(n)
           enddo
        enddo
-       if(nrecv >0) call flush(unit)
+       if(nrecv >0) flush(unit)
     endif
 
     ! copy the overlapping information into domain
@@ -3285,7 +3285,7 @@ end subroutine check_message_size
                   overlapList(m)%dir(n), overlapList(m)%rotation(n)
           enddo
        enddo
-       if( nsend > 0) call flush(unit)
+       if( nsend > 0) flush(unit)
     endif
 
     ! copy the overlapping information into domain data structure
@@ -3555,7 +3555,7 @@ end subroutine check_message_size
                   overlapList(m)%dir(n), overlapList(m)%rotation(n)
           enddo
        enddo
-       if(nrecv >0) call flush(unit)
+       if(nrecv >0) flush(unit)
     endif
 
     ! copy the overlapping information into domain
@@ -3916,7 +3916,7 @@ end subroutine check_message_size
                   overlapList(m)%dir(n), overlapList(m)%rotation(n)
           enddo
        enddo
-       if(nsend >0) call flush(unit)
+       if(nsend >0) flush(unit)
     endif
 
    ! copy the overlapping information into domain data structure
@@ -4179,7 +4179,7 @@ end subroutine check_message_size
                   overlapList(m)%dir(n), overlapList(m)%rotation(n)
           enddo
        enddo
-       if(nrecv >0) call flush(unit)
+       if(nrecv >0) flush(unit)
     endif
 
     ! copy the overlapping information into domain
@@ -5697,7 +5697,7 @@ end subroutine check_message_size
                   overlapSend(m)%dir(n), overlapSend(m)%rotation(n)
           enddo
        enddo
-       if(nsend >0) call flush(unit)
+       if(nsend >0) flush(unit)
     endif
 
     dirlist(1) = 1; dirlist(2) = 3; dirlist(3) = 5; dirlist(4) = 7
@@ -5767,7 +5767,7 @@ end subroutine check_message_size
                   overlapRecv(m)%dir(n), overlapRecv(m)%rotation(n)
           enddo
        enddo
-       if(nrecv >0) call flush(unit)
+       if(nrecv >0) flush(unit)
     endif
 
     if(nrecv >0) then

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -228,7 +228,7 @@
       end if
 !close all open fortran units
       do unit = unit_begin,unit_end
-         if( mpp_file(unit)%opened )call FLUSH(unit)
+         if( mpp_file(unit)%opened )flush(unit)
       end do
       if( dosync )call mpp_sync()
       do unit = unit_begin,unit_end
@@ -291,7 +291,7 @@
           error = NF_SYNC(mpp_file(unit)%ncid); call netcdf_err( error, mpp_file(unit) )
 #endif
       else
-          call FLUSH(unit)
+          flush(unit)
       end if
       return
     end subroutine mpp_flush

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -128,7 +128,7 @@
        write(this_pe,'(a,i6.6,a)') '.',pe,'.out'
        inquire( file=trim(configfile)//this_pe, opened=opened )
        if( opened )then
-          call FLUSH(log_unit)
+          flush(log_unit)
        else
           log_unit=get_unit()
           open( unit=log_unit, status='UNKNOWN', file=trim(configfile)//this_pe, position='APPEND', err=10 )
@@ -137,7 +137,7 @@
     else
        inquire( unit=etc_unit, opened=opened )
        if( opened )then
-          call FLUSH(etc_unit)
+          flush(etc_unit)
        else
           open( unit=etc_unit, status='UNKNOWN', file=trim(etcfile), position='APPEND', err=11 )
        end if

--- a/mpp/include/mpp_util_mpi.inc
+++ b/mpp/include/mpp_util_mpi.inc
@@ -62,7 +62,7 @@ subroutine mpp_error_basic( errortype, errormsg )
 #endif
      if(pe==root_pe)write( out_unit,'(/a/)' )trim(text)
      if( errortype.EQ.FATAL .OR. warnings_are_fatal )then
-        call FLUSH(out_unit)
+        flush(out_unit)
 #ifdef sgi_mipspro
         call TRACE_BACK_STACK_AND_PRINT()
 #endif

--- a/mpp/include/mpp_util_nocomm.inc
+++ b/mpp/include/mpp_util_nocomm.inc
@@ -60,7 +60,7 @@ subroutine mpp_error_basic( errortype, errormsg )
      write( errunit,'(/a/)' )trim(text)
      write( outunit,'(/a/)' )trim(text)
      if( errortype.EQ.FATAL .OR. warnings_are_fatal )then
-        call FLUSH(outunit)
+        flush(outunit)
 #ifdef sgi_mipspro
         call TRACE_BACK_STACK_AND_PRINT()
 #endif

--- a/mpp/include/mpp_util_sma.inc
+++ b/mpp/include/mpp_util_sma.inc
@@ -63,7 +63,7 @@ subroutine mpp_error_basic( errortype, errormsg )
 #endif
      write( outunit,'(/a/)' )trim(text)
      if( errortype.EQ.FATAL .OR. warnings_are_fatal )then
-        call FLUSH(outunit)
+        flush(outunit)
 #ifdef sgi_mipspro
         call TRACE_BACK_STACK_AND_PRINT()
 #endif

--- a/test_fms/mpp/test_mpp.F90
+++ b/test_fms/mpp/test_mpp.F90
@@ -499,7 +499,7 @@ subroutine test_gather2DV(npes,pe,root,out_unit)
   print *, 'pe, max(pe+1)=', pe, a(1)
   !pelist check
   call mpp_sync()
-  call flush(out_unit)
+  flush(out_unit)
   if( npes.GE.2 )then
      if( pe.EQ.root )print *, 'Test of pelists: bcast, sum and max using PEs 0...npes-2 (excluding last PE)'
      call mpp_declare_pelist( (/(i,i=0,npes-2)/) )


### PR DESCRIPTION
This PR converts all the `call flush()` commands to `flush()`. This is due to a fun Intel bug that appears due to the use of shared object libraries in GEOSgcm.