### PR TITLE
Change Intel Debug flags for FMS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,14 @@ endif ()
 
 set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_VECT}")
 
+# This 'resets' the Intel DEBUG flags for FMS. The stock debug flags use
+# 'all,noarg_temp_created' which seem to be too aggressive for FMS/MOM6. This
+# moves them back to the 'bounds,uninit' GEOS used to build with.
+if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel" AND CMAKE_BUILD_TYPE MATCHES Debug)
+   string(REPLACE "all,noarg_temp_created" "bounds,uninit" _tmp "${GEOS_Fortran_FLAGS_DEBUG}")
+   set (CMAKE_Fortran_FLAGS_DEBUG "${_tmp}")
+endif ()
+
 if (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_compile_options (${lib} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-kind=byte>)
 endif ()


### PR DESCRIPTION
This PR changes the Intel Debug flags for FMS (and MOM6). The issue seems to be that `-check all,noarg_temp_created` is "too much" for FMS (and MOM6). So, this change "degrades" the Intel flags to be `-check bounds,uninit` which matches the Intel Debug flags GEOS used to use before [ESMA_cmake v.3.14](https://github.com/GEOS-ESM/ESMA_cmake/tree/v3.1.4).

Note this has a companion PR in MOM6 as both need to degrade: https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/382